### PR TITLE
Added <music> tag to themes, allowing selection of background music.

### DIFF
--- a/config.c
+++ b/config.c
@@ -150,6 +150,7 @@ static const char *tag_theme_menu_border			= 	  "border";
 static const char *tag_theme_submenu				= 	"submenu";
 static const char *tag_theme_submenu_item_width		= 	  "item-width";
 static const char *tag_theme_submenu_item_height	= 	  "item-height";
+static const char *tag_theme_music				= 	"music";
 static const char *tag_theme_background				= 	"background";
 static const char *tag_theme_font					= 	"font";
 static const char *tag_theme_font_file				= 	  "font-file";
@@ -1863,6 +1864,11 @@ int config_read_theme( xmlNode *node, struct config_theme *theme ) {
 				strncpy( theme->name, content, CONFIG_NAME_LENGTH );
 				free( content );
 			}
+			else if( strcmp( (char*)node->name, tag_theme_music ) == 0 ) {
+				char *content = (char *)xmlNodeGetContent(node);
+				strncpy( theme->music, content, CONFIG_FILE_NAME_LENGTH );
+				free( content );
+                        }
 			else if( strcmp( (char*)node->name, tag_theme_background ) == 0 ) {
 				config_read_theme_background( node->children, theme );
 			}

--- a/main.c
+++ b/main.c
@@ -51,6 +51,10 @@ int main( int argc, char *arvg[] ) {
 	int config_status = 0;
 	int event;
 
+
+	// Initialise pseudo random generator   
+	srand( time( NULL ) );
+    
 #ifdef __WIN32__
 	freopen( "cabrio.out", "w", stdout );
 	freopen( "cabrio.err", "w", stderr );

--- a/sound.c
+++ b/sound.c
@@ -1,3 +1,5 @@
+#include <dirent.h>
+#include <fnmatch.h>
 #include "sound.h"
 #include "config.h"
 #include <SDL/SDL.h>
@@ -91,12 +93,48 @@ const char *sound_name( int s ) {
 }
 
 void playmusic(void) {
-	if (!music)
-		music = Mix_LoadMUS( config_get()->iface.theme.music );
-	if (music != NULL)
-		Mix_PlayMusic(music, 0);
-	if ( config_get()->iface.music_volume > 0 && config_get()->iface.music_volume <= 128 )
-		Mix_VolumeMusic(config_get()->iface.music_volume);
+#ifdef __WIN32__
+  static const char dir_separator = '\\';
+#else
+  static const char dir_separator = '/';
+#endif
+  if (!music)
+    free( music );
+  if ( config_get()->iface.theme.music[strlen(config_get()->iface.theme.music)-1] == dir_separator )
+  {
+    DIR           *dir     = opendir( config_get()->iface.theme.music );
+    struct dirent *e;
+    int           nr_music = 0;
+    if ( dir != NULL )
+    {
+      while ( ( e = readdir( dir )) != NULL )
+        if ( (fnmatch( "*.mp3", e->d_name, 0) == 0) ||  
+             (fnmatch( "*.ogg", e->d_name, 0) == 0) )
+          nr_music++;
+      if ( nr_music > 0 )
+      {
+        int sel_music = rand( )%nr_music;
+        closedir( dir );
+        dir = opendir( config_get()->iface.theme.music );
+        e   = readdir( dir );
+        while ( sel_music > 0 )
+        {
+          e = readdir( dir );
+          sel_music--;
+        }
+        char music_name[CONFIG_FILE_NAME_LENGTH];
+        snprintf( music_name, CONFIG_FILE_NAME_LENGTH, "%s%s", config_get()->iface.theme.music, e->d_name );
+        music = Mix_LoadMUS( music_name );
+      }
+      closedir( dir );
+    }
+  }
+  else
+    music = Mix_LoadMUS( config_get()->iface.theme.music );
+  if (music != NULL)
+    Mix_PlayMusic(music, 0);
+  if ( config_get()->iface.music_volume > 0 && config_get()->iface.music_volume <= 128 )
+    Mix_VolumeMusic(config_get()->iface.music_volume);
 }
 
 void stopmusic(void) {


### PR DESCRIPTION
A trailing slash appropriate for the operating system at the end will
indicate a music directory, in which case a random number from that
directory will be played.