### PR TITLE
Added <concat-path> tag to concatenates rom path with directory

### DIFF
--- a/README
+++ b/README
@@ -22,6 +22,9 @@ New options:
 <theme-sound>false/true</theme-sound>
 <music-volume>50</music-volume>
 <hide-buttons>false/true</hide-buttons>
+<concat-path>false/true</concat-path>
+
+Option for music:
 
 Put your music here /usr/share/cabrio/sounds/music.mp3
 You can also use the tag <music> placed within the <theme> tag (in a theme XML file).
@@ -31,7 +34,8 @@ In your theme file:
 <name>lmc</name>
 <music>/path/music/</music>
 
-Option direct list:
+Option for direct list:
+
 Example: keyboard touch "a" to directly switch to the first list and "b" for the second (max 5 lists)
 
 <event>
@@ -50,6 +54,43 @@ Example: keyboard touch "a" to directly switch to the first list and "b" for the
   <id>0</id>
 </device>
 </event>
+
+Option to use full path for roms:
+
+You can use directory tag to indicate a rom folder, so you don't need to use
+full path in the rom-image tag. But some emulators have problem with this, 
+because they need the full path instead Cabrio default approach: it first go
+to the directory, and then executes the emulator. So you can use concat-path
+tag, it will join both directory and rom-image in one string only:
+
+<emulators>
+  <emulator>
+    <name>MAME</name>
+    <display-name>MAME</display-name>
+    <executable>retroarch</executable>
+    <platform>Arcade</platform>
+    <directory>/home/your-user/Path/to/your/ROMs/</directory>
+    <concat-path>true</concat-path>
+    <params>
+      <param>
+        <name>-L</name>
+      </param>
+      <param>
+        <name>/usr/lib/libretro/mame_libretro.so</name>
+      </param>
+    </params>
+  </emulator>
+</emulators>
+[...]
+<game>
+  <name>After Burner II</name>
+  <platform>Arcade</platform>
+  <rom-image>aburner2.zip</rom-image>
+</game>
+
+This results:
+
+retroarch -L /usr/lib/libretro/mame_libretro.so /home/your-user/Path/to/your/ROMs/aburner2.zip
 
 ======
 

--- a/config.c
+++ b/config.c
@@ -207,6 +207,7 @@ static const char *tag_position_y		= "y-position";
 static const char *tag_position_z		= "z-position";
 static const char *tag_order			= "order";
 static const char *tag_directory		= "directory";
+static const char *tag_concat_path		= "concat-path";
 static const char *tag_color			= "color";
 static const char *tag_match			= "match";
 static const char *tag_category			= "category";
@@ -465,6 +466,11 @@ int config_read_emulator( xmlNode *node, struct config_emulator *emulator ) {
 			else if( strcmp( (char*)node->name, tag_directory ) == 0 ) {
 				char *content = (char*)xmlNodeGetContent(node);
 				strncpy( emulator->directory, content, CONFIG_FILE_NAME_LENGTH );
+				free( content );
+			}
+			else if( strcmp( (char*)node->name, tag_concat_path ) == 0 ) {
+				char *content = (char*)xmlNodeGetContent(node);
+				config_read_boolean( (char*)node->name, content, &emulator->concat_path );
 				free( content );
 			}
 			else if( strcmp( (char*)node->name, tag_platform ) == 0 ) {

--- a/include/config.h
+++ b/include/config.h
@@ -50,6 +50,7 @@ struct config_emulator {
 	char display_name[CONFIG_NAME_LENGTH];
 	char executable[CONFIG_FILE_NAME_LENGTH];
 	char directory[CONFIG_FILE_NAME_LENGTH];
+	int concat_path;
 	int is_default;
 	struct config_param *params;
 	struct config_platform *platform;


### PR DESCRIPTION
Just put < concat-path > true < /concat-path > and your directory will be concatenate with rom-image.

```
<?xml version="1.0" encoding="UTF-8"?>
<cabrio-config>
	
<emulators>
  <emulator>
    <name>MAME</name>
    <display-name>MAME</display-name>
    <executable>retroarch</executable>
    <platform>Arcade</platform>
    <directory>/home/your-user/Path/to/your/ROMs/</directory>
    <concat-path>true</concat-path>
    <params>
      <param>
        <name>-L</name>
      </param>
      <param>
        <name>/usr/lib/libretro/mame_libretro.so</name>
      </param>
    </params>
  </emulator>
</emulators>

<game-list>
	
<games>

<game>
<name>After Burner II</name>
<platform>Arcade</platform>
<rom-image>aburner2.zip</rom-image>
</game>

</games>

</game-list>

</cabrio-config>

```

It results:

```retroarch -L /usr/lib/libretro/mame_libretro.so /home/your-user/Path/to/your/ROMs/aburner2.zip```

It's useful when your emulator doesn't work with the cd /your/path/ & ./executable approach (mame libretro core has this problem, it needs the full path).