### PR TITLE
Build with bundled libav.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ OPTIMIZE=-O3 -ffast-math
 ifeq ($(DEBUG), 1)
    OPTIMIZE=-O0
 endif
-CFLAGS=-g -Wall $(OPTIMIZE) -DDATA_DIR=\"$(DATA_DIR)\"
-LDFLAGS=-lGL -lSDL2 -lSDL2_image -lSDL2_gfx -lSDL2_ttf -lSDL2_mixer -lGLU -lxml2
+CFLAGS+=-g -Wall $(OPTIMIZE) -DDATA_DIR=\"$(DATA_DIR)\"
+LDFLAGS+=-lGL -lSDL2 -lSDL2_image -lSDL2_gfx -lSDL2_ttf -lSDL2_mixer -lGLU -lxml2
 INCLUDES=-I./include -I/usr/include/libxml2
 
 # Works with libav 9.18 and 10.7 (buggy with this, weird behavior)

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,20 @@ ifeq ($(DEBUG), 1)
    OPTIMIZE=-O0
 endif
 CFLAGS=-g -Wall $(OPTIMIZE) -DDATA_DIR=\"$(DATA_DIR)\"
-LDFLAGS= -lGL -lSDL2 -lSDL2_image -lSDL2_gfx -lSDL2_ttf -lSDL2_mixer -lGLU -lxml2 \
-	-lavutil -lavformat -lavcodec -lswscale
+LDFLAGS=-lGL -lSDL2 -lSDL2_image -lSDL2_gfx -lSDL2_ttf -lSDL2_mixer -lGLU -lxml2
 INCLUDES=-I./include -I/usr/include/libxml2
+
+# Works with libav 9.18 and 10.7 (buggy with this, weird behavior)
+ifneq (,$(BUNDLED_LIBAV))
+	LIBAV_PATH=libav
+	LDFLAGS+=-L./$(LIBAV_PATH)/linux/lib -lavformat -lavcodec -lavutil -lswscale -lm -lz -lpthread
+	INCLUDES+=-I./$(LIBAV_PATH)/linux/include
+	ifeq (,$(wildcard ./$(LIBAV_PATH)/linux/lib/libavformat.a))
+		TMP:=$(shell cp -f ./build_libav_linux.sh ./$(LIBAV_PATH)/ && cd $(LIBAV_PATH)/ && ./build_libav_linux.sh)
+	endif
+else
+	LDFLAGS+=-lavutil -lavformat -lavcodec -lswscale
+endif
 
 INSTALL=/usr/bin/install -c
 

--- a/build_libav_linux.sh
+++ b/build_libav_linux.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+rm -f config.h
+echo "Building for Linux"
+
+GENERAL="
+   --disable-shared \
+   --enable-static"
+
+MODULES="\
+   --disable-avresample \
+   --disable-avdevice \
+   --disable-filters \
+   --disable-programs \
+   --disable-network \
+   --disable-avfilter \
+   --disable-encoders \
+   --disable-doc \
+   --disable-avplay \
+   --disable-avprobe \
+   --disable-avserver"
+
+VIDEO_DECODERS="\
+   --enable-decoder=h264 \
+   --enable-decoder=h263 \
+   --enable-decoder=h263p \
+   --enable-decoder=mpeg2video"
+
+AUDIO_DECODERS="\
+    --enable-decoder=aac \
+    --enable-decoder=atrac3 \
+    --enable-decoder=atrac3p \
+    --enable-decoder=mp3 \
+    --enable-decoder=pcm_s16le \
+    --enable-decoder=pcm_s8"
+  
+DEMUXERS="\
+    --enable-demuxer=mov \
+    --enable-demuxer=h264 \
+    --enable-demuxer=mpegps \
+    --enable-demuxer=mpegvideo \
+    --enable-demuxer=avi \
+    --enable-demuxer=mp3 \
+    --enable-demuxer=aac \
+    --enable-demuxer=oma \
+    --enable-demuxer=pcm_s16le \
+    --enable-demuxer=pcm_s8 \
+    --enable-demuxer=wav"
+
+VIDEO_ENCODERS="\
+	  --enable-encoder=huffyuv \
+	  --enable-encoder=ffv1 \
+	  --enable-encoder=mjpeg"
+
+AUDIO_ENCODERS="\
+	  --enable-encoder=pcm_s16le"
+
+MUXERS="\
+  	--enable-muxer=avi"
+
+PARSERS="\
+    --enable-parser=h264 \
+    --enable-parser=mpeg4video \
+    --enable-parser=mpegvideo \
+    --enable-parser=aac \
+    --enable-parser=mpegaudio"
+
+
+./configure \
+    --prefix=./linux \
+    ${GENERAL} \
+    --extra-cflags="-D__STDC_CONSTANT_MACROS -O3" \
+    --enable-zlib \
+    --enable-pic \
+    --disable-yasm \
+    --disable-everything \
+    --enable-protocol=file \
+    ${MODULES} \
+    ${VIDEO_DECODERS} \
+    ${AUDIO_DECODERS} \
+    ${VIDEO_ENCODERS} \
+    ${AUDIO_ENCODERS} \
+    ${DEMUXERS} \
+    ${MUXERS} \
+    ${PARSERS}
+
+make clean
+make install

--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,11 @@
 Source: cabrio
 Section: otherosfs
-Priority: extra
+Priority: optional
 Maintainer: Steve Maddison <steve@cabrio-fe.org>
-Build-Depends: debhelper (>= 9), libavcodec-dev, libavutil-dev, libavformat-dev, libsdl2-dev, libsdl2-image-dev, libsdl2-gfx-dev, libsdl2-mixer-dev, libsdl2-ttf-dev, libswscale-dev, libxml2-dev
-Standards-Version: 3.9.5
+Build-Depends: debhelper (>= 9), libsdl2-dev, libsdl2-image-dev, libsdl2-gfx-dev, libsdl2-mixer-dev, libsdl2-ttf-dev, libxml2-dev
+# libavcodec-dev, libavutil-dev, libavformat-dev, libswscale-dev
+Standards-Version: 3.9.6
 Homepage: http://www.cabrio-fe.org
-Vcs-Git: git://github.com/SteveMaddison/cabrio.git
-Vcs-Browser: https://github.com/SteveMaddison/cabrio
 
 Package: cabrio
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -1,30 +1,18 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
-# Uncomment this to turn on verbose mode.
-#export DH_VERBOSE=1
-
-QUILT=QUILT_PATCHES=debian/patches quilt --quiltrc /dev/null
-PATCH := $(QUILT) push -a || [ "$$($(QUILT) applied)" = "$$(grep -v '^\#' debian/patches/series)" ]
-UNPATCH := $(QUILT) pop -a || [ "$$($(QUILT) applied 2>&1)" = "No patches applied" ]
-
-patch:
-	$(PATCH)
-	
-unpatch:
-	$(UNPATCH)
+export DEB_CXXFLAGS_MAINT_STRIP=-g -O2
+export DEB_CFLAGS_MAINT_STRIP=-g -O2
 
 %:
 	dh $@ --parallel
 
+override_dh_auto_build:
+	# Build with libav 9.18, you have to download it, see https://github.com/fredbcode/cabrio/pull/13
+	dh_auto_build -- BUNDLED_LIBAV=1
+
 override_dh_auto_install:
 	# Add here commands to install the package into debian/cabrio.
-	$(MAKE) DESTDIR=$(CURDIR)/debian/cabrio \
+	dh_auto_install -- DESTDIR=$(CURDIR)/debian/cabrio \
 		BIN_DIR=$(CURDIR)/debian/cabrio/usr/bin \
 		DATA_DIR=$(CURDIR)/debian/cabrio/usr/share/cabrio \
 		install


### PR DESCRIPTION
This commit allows build cabrio with bundled libav. I tested only with ubuntu 14.04.

Download libav 9.18 and extract inside cabrio source, rename the libav folder to "libav", and build with:

make BUNDLED_LIBAV=1

With libav 10.7 you get buggy/weird behavior in the chasehq_good
